### PR TITLE
Cancel requests

### DIFF
--- a/dev/graphql.js
+++ b/dev/graphql.js
@@ -4,7 +4,7 @@ const uri = 'http://localhost:4000/';
 
 // A function that gets data from a GraphQL server via a POST request.
 // Adapted from https://graphql.org/graphql-js/graphql-clients/
-function graphqlQuery(uri, query, variables={}) {
+function graphqlQuery(uri, query, variables={}, abortSignal=undefined) {
   return fetch(uri, {
     method: 'POST',
     headers: {
@@ -14,7 +14,8 @@ function graphqlQuery(uri, query, variables={}) {
     body: JSON.stringify({
       query,
       variables,
-    })
+    }),
+    signal: abortSignal,
   }).then(r => r.json());
 }
 // TODO: implement error handling

--- a/dev/lis-gene-search.html
+++ b/dev/lis-gene-search.html
@@ -38,7 +38,7 @@
       `;
     
     // the search function given to the LIS gene search Web Component
-    function getGenes(searchData, page=1) {
+    function getGenes(searchData, page, {abortSignal}) {
       const keyword = searchData['query'];
       const pageSize = 10;
       const start = (page-1)*pageSize;
@@ -46,7 +46,7 @@
       const variables = {keyword, start, size: pageSize+1};
       // returns a Promise that resolves to an array of Gene objects the gene search
       // Web Component knows how to parse: {name: string, description: string}[]
-      return graphqlQuery(uri, geneQuery, variables)
+      return graphqlQuery(uri, geneQuery, variables, abortSignal)
         .then(({data}) => {
           // compute if there's a next page
           const hasNext = pageSize+1 === data.geneSearch.length;

--- a/dev/lis-trait-search.html
+++ b/dev/lis-trait-search.html
@@ -38,7 +38,7 @@
     `;
     
     // the search function given to the LIS gene search Web Component
-    function getTraits(searchData, page=1) {
+    function getTraits(searchData, page, {abortSignal}) {
       const keyword = searchData['query'];
       const pageSize = 10;
       const start = (page-1)*pageSize;
@@ -46,7 +46,7 @@
       const variables = {keyword, start, size: pageSize+1};
       // returns a Promise that resolves to an array of Trait objects the trait search
       // Web Component knows how to parse: {name: string, description: string}[]
-      return graphqlQuery(uri, traitQuery, variables)
+      return graphqlQuery(uri, traitQuery, variables, abortSignal)
         .then(({data}) => {
           // compute if there's a next page
           const hasNext = pageSize+1 === data.traitSearch.length;

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,2 +1,3 @@
+export * from './lis-cancel-promise-controller';
 export * from './lis-dom-content-loaded-controller';
 export * from './lis-query-string-parameters-controller';

--- a/src/controllers/lis-cancel-promise-controller.ts
+++ b/src/controllers/lis-cancel-promise-controller.ts
@@ -1,0 +1,107 @@
+import {ReactiveController, ReactiveControllerHost} from 'lit';
+
+
+type CancelState = {abortSignal: AbortSignal; wrapCount: Number; promise?: Promise<void>};
+
+
+// A controller that allows Promises to be cancelled.
+// NOTE: All Promises made cancellable with this controller are cancelled with
+// the same AbortSignal. Multiple instances of the controller should be used
+// if multiple signals are desired.
+export class LisCancelPromiseController implements ReactiveController {
+
+  host: ReactiveControllerHost;
+
+  // @ts-ignore
+  private _abortController: AbortController;
+  // @ts-ignore
+  abortSignal: AbortSignal;
+
+  // wrap state with promise to avoid race conditions
+  // @ts-ignore
+  private _cancelState: CancelState;
+
+  private _listeners: EventListener[] = [];
+
+  constructor(host: ReactiveControllerHost) {
+    (this.host = host).addController(this);
+    // members ignored because they're not definitely assigned in the constructor
+    this._initialize();
+  }
+
+  hostConnected() {
+    this._addEventListener();
+  }
+
+  hostDisconnected() {
+    this.abortSignal.removeEventListener('abort', this._aborted.bind(this));
+  }
+
+  // makes a Promise cancellable by racing it against a Promise that only cancels
+  wrapPromise<T>(promise: Promise<T>): Promise<T> {
+    // create a Promise race that will reject when the abort signal emits
+    const cancelState = this._cancelState;
+    // @ts-ignore
+    cancelState.wrapCount += 1;
+    return Promise.race([promise, cancelState.promise]) as Promise<T>;
+  }
+
+  // adds a listener to the abort event
+  addListener(listener: EventListener): void {
+    // each listener is called in the scope of the host
+    this._listeners.push(listener.bind(this.host));
+  }
+
+  // cancels all Promises that have been made since the last cancel
+  cancel(): void {
+    this._abortController.abort();
+  }
+
+  private _addEventListener(): void {
+    this.abortSignal.addEventListener('abort', this._aborted.bind(this), {once: true});
+  }
+
+  // creates the Promise that only cancels
+  private _initialize(): void {
+    // initialize the AbortController and the AbortSignal variable
+    this._abortController = new AbortController();
+    this.abortSignal = this._abortController.signal;
+    // add the abort event listener
+    this._addEventListener();
+    // intialize the cancel state
+    let cancelState: CancelState = {abortSignal: this.abortSignal, wrapCount: 0};
+    cancelState.promise = new Promise<void>((_, reject) => {
+        // cancel the promise when the abort signal emits
+        cancelState.abortSignal.addEventListener(
+          'abort',
+          (event: Event) => reject(event),
+          {once: true},
+        );
+      })
+      // the default error handler
+      .catch((error: Error) => {
+        // only throw an error if a Promise downstream can catch it
+        if (cancelState.wrapCount > 0) {
+          throw error;
+        }
+      });
+    this._cancelState = cancelState;
+  }
+
+  // calls all listeners of the aobrt event
+  private _aborted(event: Event): void {
+    // create a new cancel only promise
+    this._initialize();
+    // redraw the host
+    this.host.requestUpdate();
+    // wait for the redraw to complete in case any listeners rely on state from the template
+    this.host.updateComplete
+      .then(() => {
+        // call each listener
+        this._listeners.forEach((listener) => {
+          listener(event);
+        });
+      });
+  }
+
+}

--- a/src/mixins/lis-paginated-search-mixin.ts
+++ b/src/mixins/lis-paginated-search-mixin.ts
@@ -26,7 +26,7 @@ export type PaginatedSearchResults<SearchResult> = {
 };
 
 // optional parameters that may be given to a search
-export type SearchOptions = {signal?: AbortSignal};
+export type SearchOptions = {abortSignal?: AbortSignal};
 
 // the search function
 export type SearchFunction<SearchData, SearchResult> =
@@ -190,7 +190,7 @@ class LisPaginatedSearchElement extends superClass {
       this._setAlert(message, 'primary');
       this.queryStringController.setParameters({page, ...this._data});
       this.cancelPromiseController.cancel();
-      const options = {signal: this.cancelPromiseController.abortSignal};
+      const options = {abortSignal: this.cancelPromiseController.abortSignal};
       const searchPromise = this.searchFunction(this._data, page, options);
       this.cancelPromiseController.wrapPromise(searchPromise)
         .then(


### PR DESCRIPTION
This PR adds a Lit controller that allows Promises to be effectively cancelled, which isn't natively supported by any Web standards. The controller is used to cancel in-flight HTTP requests that are superseded by new requests.