### PR TITLE
Fixed a bug in the gene search linkout example.

### DIFF
--- a/dev/examples/lis-gene-search-with-linkouts.html
+++ b/dev/examples/lis-gene-search-with-linkouts.html
@@ -99,7 +99,8 @@
       window.onload = (event) => {
         const modal = document.getElementById('modal');
         modal.addEventListener('toggle', (event) => {
-          const identifier = event.explicitOriginalTarget.dataset.gene;
+          const [{$el: link}, ...uikitComponents] = event.detail;
+          const identifier = link.dataset.gene;
           linkoutElement.getLinkouts([identifier]);
         });
       };


### PR DESCRIPTION
Previously the example used the explicitOriginalTarget event property, which is non-standard and only worked in Firefox. The code has been updated to use UIkit's own internal API, which appears to be quite stable.