### PR TITLE
Enable HTML in gene description

### DIFF
--- a/src/lis-gene-search-element.ts
+++ b/src/lis-gene-search-element.ts
@@ -497,7 +497,7 @@ LisPaginatedSearchMixin(LitElement)<GeneSearchData, GeneSearchResult>() {
           <b>${unsafeHTML(gene.identifier)}</b> (${name}) <span class="uk-text-italic">${unsafeHTML(gene.genus)} ${unsafeHTML(gene.species)}</span> ${unsafeHTML(gene.strain)}
         </div>
         <div class="uk-text-italic">
-          ${ gene.description }
+          ${ unsafeHTML(gene.description) }
         </div>
         ${location}
         ${geneFamily}


### PR DESCRIPTION
For example, add hyperlinks around GO and IPR strings (use case for PeanutBase).