### PR TITLE
Gene search element "only" parameter

### DIFF
--- a/dev/lis-gene-search-element.html
+++ b/dev/lis-gene-search-element.html
@@ -31,10 +31,15 @@
         This allows users to share specific pages from a search via the URL and for the search history to be navigated via the Web browser's forward and back buttons.
         If the query string parameters are present when the component loads then a search will be automatically performed with the query string parameter values.
       </p>
+      <p>
+        A search for a specific genus can be enabled by specifying the <code>only</code> attribute in the HTML tag.
+        In this example, the <code>only</code> attribute is set to <code>glycine</code> which limits the genus selector to <code>glycine</code>.
+        Not including the <code>only</code> attribute, or including a genus that does not exist, will allow the user to select any genus.
+      </p>
       <hr>
 
       <!-- the custom gene search element -->
-      <lis-gene-search-element id="gene-search"></lis-gene-search-element>
+      <lis-gene-search-element id="gene-search" only="glycine"></lis-gene-search-element>
 
     </div>
 

--- a/dev/lis-gene-search-element.html
+++ b/dev/lis-gene-search-element.html
@@ -33,13 +33,12 @@
       </p>
       <p>
         A search for a specific genus can be enabled by specifying the <code>only</code> attribute in the HTML tag.
-        In this example, the <code>only</code> attribute is set to <code>glycine</code> which limits the genus selector to <code>glycine</code>.
         Not including the <code>only</code> attribute, or including a genus that does not exist, will allow the user to select any genus.
       </p>
       <hr>
 
       <!-- the custom gene search element -->
-      <lis-gene-search-element id="gene-search" only="glycine"></lis-gene-search-element>
+      <lis-gene-search-element id="gene-search"></lis-gene-search-element>
 
     </div>
 

--- a/src/lis-gene-search-element.ts
+++ b/src/lis-gene-search-element.ts
@@ -167,6 +167,15 @@ export type GeneSearchFunction =
  *   geneSearchElement.formDataFunction = getGeneFormData;
  * </script>
  * ```
+ *
+ * @example
+ * The {@link only | `only`} property can be used to only show a single genus in the search form.
+ * This is useful for sites that only have a single genus like SoyBase. For example:
+ * ```html
+ * <!-- add the Web Component to your HTML -->
+ * <lis-gene-search-element id="gene-search" only="Glycine"></lis-gene-search-element>
+ * ```
+ *
  */
 @customElement('lis-gene-search-element')
 export class LisGeneSearchElement extends
@@ -175,7 +184,6 @@ LisPaginatedSearchMixin(LitElement)<GeneSearchData, GeneSearchResult>() {
   /**
    * Property to only show a single genus in the search form.
    * Useful for sites that only have a single genus like SoyBase.
-   * Example: <lis-gene-search-element only="Glycine"></lis-gene-search-element>
    */
   @property({type: String})
   only: string = '';

--- a/src/lis-gene-search-element.ts
+++ b/src/lis-gene-search-element.ts
@@ -172,6 +172,17 @@ export type GeneSearchFunction =
 export class LisGeneSearchElement extends
 LisPaginatedSearchMixin(LitElement)<GeneSearchData, GeneSearchResult>() {
 
+  /**
+   * Property to only show a single genus in the search form.
+   * Useful for sites that only have a single genus like SoyBase.
+   * Example: <lis-gene-search-element only="Glycine"></lis-gene-search-element>
+   */
+  @property({type: String})
+  only: string = '';
+  
+
+
+
   /** @ignore */
   // used by Lit to style the Shadow DOM
   // not necessary but exclusion breaks TypeDoc
@@ -334,11 +345,25 @@ LisPaginatedSearchMixin(LitElement)<GeneSearchData, GeneSearchResult>() {
   }
 
   // renders the genus selector
-  private _renderGenusSelector() {
+  private _renderGenusSelector(onlyGenus: string) {
+    // if onlyGenus is set, render a disabled select element with the onlyGenus value as the selected and only option.
+    if (onlyGenus.length > 0) {
+      const genus = this.formData.genuses.find(({genus}) => genus === onlyGenus.charAt(0).toUpperCase() + onlyGenus.slice(1));
+      if (genus) {
+        this.selectedGenus = this.formData.genuses.indexOf(genus)+1;
+        return html`
+          <select class="uk-select uk-form-small" name="genus" disabled>
+            <option value="${genus.genus}" selected>${genus.genus}</option>
+          </select>
+        `;
+      }
+    }
+    // otherwise, render a normal select element
     const options =
-      this.formData.genuses.map(({genus}) => {
+        this.formData.genuses.map(({genus}) => {
         return html`<option value="${genus}">${genus}</option>`;
       });
+
     return html`
       <select class="uk-select uk-form-small" name="genus"
         .selectedIndex=${live(this.selectedGenus)}
@@ -408,7 +433,7 @@ LisPaginatedSearchMixin(LitElement)<GeneSearchData, GeneSearchResult>() {
   override renderForm() {
 
     // render the form's selectors
-    const genusSelector = this._renderGenusSelector();
+    const genusSelector = this._renderGenusSelector(this.only);
     const speciesSelector = this._renderSpeciesSelector();
     const strainSelector = this._renderStrainSelector();
 


### PR DESCRIPTION
This branch adds an "only" parameter into `lis-gene-search-element`.
When specified in the html tag, (ex: `<lis-gene-search-element id="gene-search" only="Glycine"></lis-gene-search-element>`), only the specified genus will be rendered in the dropdown list. The genus will be automatically selected and the dropdown will be disabled.   
Entering nothing or a genus that doesn't exist results in the normal element behavior (rendering all genuses). 