### PR TITLE
Fixed repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Web Components for the Legume Information System and other AgBio databases",
   "repository": {
     "type": "git",
-    "url": "https://github.com/apollographql/web-components"
+    "url": "https://github.com/legumeinfo/web-components"
   },
   "bugs": {
     "url": "https://github.com/legumeinfo/web-components/issues"


### PR DESCRIPTION
I just noticed on NPM that the repository URL is wrong! This PR fixes that. I'm going to roll a v1.1.1 release to push it up to NPM.