### PR TITLE
Updated GraphQL queries to 5.1.0.4 data model

### DIFF
--- a/dev/examples/lis-gene-search-with-linkouts.html
+++ b/dev/examples/lis-gene-search-with-linkouts.html
@@ -104,7 +104,7 @@
             strain { identifier }
             geneFamilyAssignments { geneFamily { identifier } }
             panGeneSets { identifier }
-            locations { chromosome { identifier } supercontig { identifier } start end strand }
+            locations { locatedOn { identifier } start end strand }
           }
           pageInfo {
             pageSize

--- a/dev/lis-gene-search-element.html
+++ b/dev/lis-gene-search-element.html
@@ -109,7 +109,7 @@
             strain { identifier }
             geneFamilyAssignments { geneFamily { identifier } }
             panGeneSets { identifier }
-            locations { chromosome { identifier } supercontig { identifier } start end strand }
+            locations { locatedOn { identifier } start end strand }
           }
           pageInfo {
             hasNextPage

--- a/dev/lis-pangene-lookup-element.html
+++ b/dev/lis-pangene-lookup-element.html
@@ -59,11 +59,11 @@
           results {
             annotationVersion
             assemblyVersion
+            organism {
+              genus
+              species
+            }
             strain {
-              organism {
-                genus
-                species
-              }
               identifier
             }
           }
@@ -86,11 +86,11 @@
             data.chromosomes.results.forEach(({
               annotationVersion,
               assemblyVersion,
+              organism: {
+                genus,
+                species,
+              },
               strain: {
-                organism: {
-                  genus,
-                  species,
-                },
                 identifier,
               },
             }) => {

--- a/dev/lis-qtl-search-element.html
+++ b/dev/lis-qtl-search-element.html
@@ -61,7 +61,9 @@
             }
             start
             end
-            markerNames
+            markers {
+               name
+            }
           }
           pageInfo {
             hasNextPage

--- a/dev/lis-trait-association-search-element.html
+++ b/dev/lis-trait-association-search-element.html
@@ -102,7 +102,7 @@
                     genus
                     species
                   }
-                  dataSet {
+                  dataSets {
                     publication {
                       firstAuthor
                       pubMedId
@@ -119,7 +119,7 @@
                     genus
                     species
                   }
-                  dataSet {
+                  dataSets {
                     publication {
                       firstAuthor
                       pubMedId


### PR DESCRIPTION
This PR is mostly gratuitous since the affected code will soon be replaced by a library. It mostly serves as a means of testing the 5.1.0.4. changes to the GraphQL server.